### PR TITLE
Fix login form to use username instead of email

### DIFF
--- a/_chapters/create-a-login-page.md
+++ b/_chapters/create-a-login-page.md
@@ -51,10 +51,10 @@ export default class Login extends Component {
       <div className="Login">
         <form onSubmit={this.handleSubmit}>
           <FormGroup controlId="username" bsSize="large">
-            <ControlLabel>Email</ControlLabel>
+            <ControlLabel>Username</ControlLabel>
             <FormControl
               autoFocus
-              type="email"
+              type="text"
               value={this.state.username}
               onChange={this.handleChange} />
           </FormGroup>


### PR DESCRIPTION
Change the input field to receive a username instead of email. The authentication call is done with username and not the email address.