### PR TITLE
Remove --save (optional since npm 5.0.0)

### DIFF
--- a/_chapters/add-support-for-es6-es7-javascript.md
+++ b/_chapters/add-support-for-es6-es7-javascript.md
@@ -28,7 +28,7 @@ $ npm install --save-dev \
     webpack \
     webpack-node-externals
 
-$ npm install --save babel-runtime
+$ npm install babel-runtime
 ```
 
 Most of the above packages are only needed while we are building our project and they won't be deployed to our Lambda functions. We are using the `serverless-webpack` plugin to help trigger the Webpack build when we run our Serverless commands. The `webpack-node-externals` is necessary because we do not want Webpack to bundle our `aws-sdk` module, since it is not compatible.

--- a/_chapters/code-splitting-in-create-react-app.md
+++ b/_chapters/code-splitting-in-create-react-app.md
@@ -201,7 +201,7 @@ It was mentioned above that you can add a loading spinner while the import is in
 All you need to do to use it is install it.
 
 ``` bash
-$ npm install --save react-loadable
+$ npm install react-loadable
 ```
 
 Use it instead of the `asyncComponent` that we had above.

--- a/_chapters/handle-routes-with-react-router.md
+++ b/_chapters/handle-routes-with-react-router.md
@@ -17,7 +17,7 @@ Let's start by installing React Router. We are going to be using the React Route
 <img class="code-marker" src="{{ site.url }}/assets/s.png" />Run the following command in your working directory.
 
 ``` bash
-$ npm install react-router-dom --save
+$ npm install react-router-dom
 ```
 
 This installs the NPM package and adds the dependency to your `package.json`.

--- a/_chapters/login-with-aws-cognito.md
+++ b/_chapters/login-with-aws-cognito.md
@@ -35,7 +35,7 @@ We are going to use the NPM module `amazon-cognito-identity-js` to login to Cogn
 <img class="code-marker" src="{{ site.url }}/assets/s.png" />Install it by running the following in your project root.
 
 ``` bash
-$ npm install amazon-cognito-identity-js --save
+$ npm install amazon-cognito-identity-js
 ```
 
 <img class="code-marker" src="{{ site.url }}/assets/s.png" />And include the following in the header of our `src/containers/Login.js`.

--- a/_chapters/setup-bootstrap.md
+++ b/_chapters/setup-bootstrap.md
@@ -14,7 +14,7 @@ A big part of writing web applications is having a UI Kit to help create the int
 <img class="code-marker" src="{{ site.url }}/assets/s.png" />Run the following command in your working directory
 
 ``` bash
-$ npm install react-bootstrap --save
+$ npm install react-bootstrap
 ```
 
 This installs the NPM package and adds the dependency to your `package.json`.


### PR DESCRIPTION
[Since npm 5.0.0](http://blog.npmjs.org/post/161081169345/v500), `npm install` defaults to `--save`. There have been no changes to `--save-dev`.

Apologies for 5 commits, GitHub allows you to squash them into one while merging.