### PR TITLE
Update babel loader in webpack

### DIFF
--- a/_chapters/add-support-for-es6-es7-javascript.md
+++ b/_chapters/add-support-for-es6-es7-javascript.md
@@ -55,7 +55,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.js$/,
-      loaders: ['babel'],
+      loaders: ['babel-loader'],
       include: __dirname,
       exclude: /node_modules/,
     }]


### PR DESCRIPTION
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'babel-loader' instead of 'babel',
                 see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed