### PR TITLE
Unnecessary constant

### DIFF
--- a/_chapters/add-a-create-note-api.md
+++ b/_chapters/add-a-create-note-api.md
@@ -259,7 +259,7 @@ export async function main(event, context, callback) {
   };
 
   try {
-    const result = await dynamoDbLib.call('put', params);
+    await dynamoDbLib.call('put', params);
     callback(null, success(params.Item));
   }
   catch(e) {


### PR DESCRIPTION
Unnecessary constant. Constant `result` wasn't being used.