### PR TITLE
Updating the 403 troubleshooting section with Git Bash on Windows workaround

### DIFF
--- a/_chapters/test-the-apis.md
+++ b/_chapters/test-the-apis.md
@@ -85,6 +85,8 @@ And that's it for the backend! Next we are going to move on to creating the fron
   - Ensure the `--path-template` option in the `apig-test` command is pointing to `/notes` and not `notes`. The format matters for securely signing our request.
 
   - There are no trailing slashes for `YOUR_API_GATEWAY_URL`. In our case, the URL is `https://ly55wbovq4.execute-api.us-east-1.amazonaws.com/prod`. Notice that it does not end with a `/`.
+  
+  - If you're on Windows and are using Git Bash, try adding a trailing slash to `YOUR_API_GATEWAY_URL` while removing the leading slash from `--path-template`. In our case, it would result in `--invoke-url https://ly55wbovq4.execute-api.us-east-1.amazonaws.com/prod/ --path-template notes`.
 
   There is a good chance that this error is happening even before our Lambda functions are invoked. So we can start by making sure our IAM Roles are configured properly for our Identity Pool. Follow the steps as detailed in our [Debugging Serverless API Issues]({% link _chapters/debugging-serverless-api-issues.md %}#missing-iam-policy) chapter to ensure that your IAM Roles have the right set of permissions. 
 


### PR DESCRIPTION
Updated the troubleshooting section to help fellow Git Bash users. I was getting the following:

`$ apig-test
   --username admin@example.com
   --password Passw0rd!
   --user-pool-id us-east-1_VxxxM
   --app-client-id 4xxxd
   --cognito-region us-east-1
   --identity-pool-id us-east-1:fxxx1
   --invoke-url https://9xxxf.execute-api.us-east-1.amazonaws.com/prod
   --api-gateway-region us-east-1
   --path-template /notes
   --method POST
   --body "{\"content\":\"hello world\",\"attachment\":\"hello.jpg\"}"
Authenticating with User Pool
Getting temporary credentials
Making API request
{ status: 403,
  statusText: 'Forbidden',
  data: { message: 'Forbidden' } }
`

By moving the slash from --path-template to --invoke-url it started working:

`$ apig-test
   --username admin@example.com
   --password Passw0rd!
   --user-pool-id us-east-1_VxxxM
   --app-client-id 4jxxxld
   --cognito-region us-east-1
   --identity-pool-id us-east-1:fdxxxb1
   --invoke-url https://9xxxf.execute-api.us-east-1.amazonaws.com/prod/
   --api-gateway-region us-east-1
   --path-template notes
   --method POST
   --body "{\"content\":\"hello world\",\"attachment\":\"hello.jpg\"}"
Authenticating with User Pool
Getting temporary credentials
Making API request
{ status: 200,
  statusText: 'OK',
  data:
   { userId: 'us-east-1:4xxx3',
     noteId: 'exxxf',
     content: 'hello world',
     attachment: 'hello.jpg',
     createdAt: 1511260183884 } }
`
