### PR TITLE
Fix code snippet with tableName from environment

### DIFF
--- a/_chapters/use-environment-variables-in-lambda-functions.md
+++ b/_chapters/use-environment-variables-in-lambda-functions.md
@@ -29,7 +29,8 @@ We need to change the `TableName: "notes"` line to use the relevant table name. 
 # These environment variables are made available to our functions
 # under process.env.
 environment:
-  tableName: ${self:custom.tableName}
+  tableName:
+    Ref: NotesTable
 ```
 
 As we noted there, we can reference this in our Lambda functions as `process.env.tableName`.


### PR DESCRIPTION
This page leads the user to think that the `tableName` should be replaced with `${self:custom.tableName}` which does not exist.

This PR makes sure the working snippet is shown.