### PR TITLE
Set proper UsernameAttributes in Cognito User Pool

### DIFF
--- a/_chapters/configure-cognito-user-pool-in-serverless.md
+++ b/_chapters/configure-cognito-user-pool-in-serverless.md
@@ -21,7 +21,7 @@ Resources:
       # Generate a name based on the stage
       UserPoolName: ${self:custom.stage}-user-pool
       # Set email as an alias
-      AliasAttributes:
+      UsernameAttributes:
         - email
       AutoVerifiedAttributes:
         - email


### PR DESCRIPTION
The current configuration does not create a User Pool similar to the one described on https://serverless-stack.com/chapters/create-a-cognito-user-pool.html, and the user cannot sign up with email/password.

This PR fixes that configuration
