### PR TITLE
Refactored an unnecessary ternary operator

### DIFF
--- a/_chapters/add-an-update-note-api.md
+++ b/_chapters/add-an-update-note-api.md
@@ -33,8 +33,8 @@ export async function main(event, context, callback) {
     // 'ExpressionAttributeValues' defines the value in the update expression
     UpdateExpression: "SET content = :content, attachment = :attachment",
     ExpressionAttributeValues: {
-      ":attachment": data.attachment ? data.attachment : null,
-      ":content": data.content ? data.content : null
+      ":attachment": data.attachment || null,
+      ":content": data.content || null
     },
     ReturnValues: "ALL_NEW"
   };


### PR DESCRIPTION
Not sure if you have a preference but I typically revert null ternary operators to `variable || null`!