### PR TITLE
fix a small typo

### DIFF
--- a/_chapters/list-all-the-notes.md
+++ b/_chapters/list-all-the-notes.md
@@ -9,7 +9,7 @@ comments_id: list-all-the-notes/156
 
 Now that we are able to create a new note, let's create a page where we can see a list of all the notes a user has created. It makes sense that this would be the homepage (even though we use the `/` route for the landing page). So we just need to conditionally render the landing page or the homepage depending on the user session.
 
-Currently, our Home containers is very simple. Let's add the conditional rendering in there.
+Currently, our Home container is very simple. Let's add the conditional rendering in there.
 
 <img class="code-marker" src="/assets/s.png" />Replace our `src/containers/Home.js` with the following.
 


### PR DESCRIPTION
used the plural version of `container` when it shouldn't