### PR TITLE
Replacing static file size with a dynamic lookup

### DIFF
--- a/_chapters/add-the-create-note-page.md
+++ b/_chapters/add-the-create-note-page.md
@@ -52,7 +52,7 @@ export default class NewNote extends Component {
     event.preventDefault();
 
     if (this.file && this.file.size > config.MAX_ATTACHMENT_SIZE) {
-      alert("Please pick a file smaller than 5MB");
+      alert(`Please pick a file smaller than ${config.MAX_ATTACHMENT_SIZE/1000000} MB.`);
       return;
     }
 

--- a/_chapters/call-the-create-api.md
+++ b/_chapters/call-the-create-api.md
@@ -24,7 +24,7 @@ handleSubmit = async event => {
   event.preventDefault();
 
   if (this.file && this.file.size > config.MAX_ATTACHMENT_SIZE) {
-    alert("Please pick a file smaller than 5MB");
+    alert(`Please pick a file smaller than ${config.MAX_ATTACHMENT_SIZE/1000000} MB.`);
     return;
   }
 

--- a/_chapters/render-the-note-form.md
+++ b/_chapters/render-the-note-form.md
@@ -34,7 +34,7 @@ handleSubmit = async event => {
   event.preventDefault();
 
   if (this.file && this.file.size > config.MAX_ATTACHMENT_SIZE) {
-    alert("Please pick a file smaller than 5MB");
+    alert(`Please pick a file smaller than ${config.MAX_ATTACHMENT_SIZE/1000000} MB.`);
     return;
   }
 

--- a/_chapters/save-changes-to-a-note.md
+++ b/_chapters/save-changes-to-a-note.md
@@ -24,7 +24,7 @@ handleSubmit = async event => {
   event.preventDefault();
 
   if (this.file && this.file.size > config.MAX_ATTACHMENT_SIZE) {
-    alert("Please pick a file smaller than 5MB");
+    alert(`Please pick a file smaller than ${config.MAX_ATTACHMENT_SIZE/1000000} MB.`);
     return;
   }
 

--- a/_chapters/upload-a-file-to-s3.md
+++ b/_chapters/upload-a-file-to-s3.md
@@ -64,7 +64,7 @@ handleSubmit = async event => {
   event.preventDefault();
 
   if (this.file && this.file.size > config.MAX_ATTACHMENT_SIZE) {
-    alert("Please pick a file smaller than 5MB");
+    alert(`Please pick a file smaller than ${config.MAX_ATTACHMENT_SIZE/1000000} MB.`);
     return;
   }
 


### PR DESCRIPTION
Hi, as mentioned [here](https://discourse.serverless-stack.com/t/add-the-create-note-page/107/11), I'd like to suggest replacing the static file size alerts with dynamic lookups based on our config. Please let me know if you would like me to change anything.