### PR TITLE
Update add-a-list-all-the-notes-api.md

### DIFF
--- a/_chapters/add-a-list-all-the-notes-api.md
+++ b/_chapters/add-a-list-all-the-notes-api.md
@@ -34,7 +34,7 @@ export async function main(event, context, callback) {
   };
 
   try {
-    const result = await dynamoDbLib.call("query", params);
+    const result = await dynamoDbLib.call("scan", params);
     // Return the matching list of items in response body
     callback(null, success(result.Items));
   } catch (e) {


### PR DESCRIPTION
dynamoDbLib.call("query", params) gives me a 500 error, and i think it's doing so for others as well, see https://discourse.serverless-stack.com/t/list-all-the-notes-in-the-table-for-all-users/252