### PR TITLE
fixed alert() to display error message instead of Error object

### DIFF
--- a/_chapters/call-the-create-api.md
+++ b/_chapters/call-the-create-api.md
@@ -36,7 +36,7 @@ handleSubmit = async event => {
     });
     this.props.history.push("/");
   } catch (e) {
-    alert(e);
+    alert(e.message);
     this.setState({ isLoading: false });
   }
 }


### PR DESCRIPTION
The error that thrown from `API.post()` is an object type. So, we should display an error message by `e.message`, not `e`