### PR TITLE
change a regex and contents on Redirect on login chapter

### DIFF
--- a/_chapters/redirect-on-login.md
+++ b/_chapters/redirect-on-login.md
@@ -52,7 +52,7 @@ export default ({ component: C, props: cProps, ...rest }) => {
 };
 ```
 
-<img class="code-marker" src="/assets/s.png" />And remove the following from the `handleSubmit` method in `src/containers/Login.js`.
+<img class="code-marker" src="/assets/s.png" />And remove the following from the `handleSubmit` method in `src/containers/Login.js` and from the `handleConfirmationSubmit` method in `src/containers/Signup.js`.
 
 ``` coffee
 this.props.history.push("/");

--- a/_chapters/redirect-on-login.md
+++ b/_chapters/redirect-on-login.md
@@ -15,9 +15,7 @@ Let's start by adding a method to read the `redirect` URL from the querystring.
 
 ``` coffee
 function querystring(name, url = window.location.href) {
-  name = name.replace(/[[]]/g, "\\$&");
-
-  const regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)", "i");
+  const regex = new RegExp("[?&]" + name + "(=([^&#]*))", "i");
   const results = regex.exec(url);
 
   if (!results) {
@@ -27,7 +25,7 @@ function querystring(name, url = window.location.href) {
     return "";
   }
 
-  return decodeURIComponent(results[2].replace(/\+/g, " "));
+  return decodeURI(results[2].replace(/\+/g, " "));
 }
 ```
 


### PR DESCRIPTION
- We always call `queryString()` with `"redirect"` as an argument, so I think it's not necessary to use regex to escape special characters on `name` variable.
- We want to capture a value after `=` to `results[2]`, so it's not necessary to capture `&` or `#` or `$` to `results[1]`. 
- I'm not sure for this point. As my understanding, a string value of `window.location.href` is encoded by `encodeURI()`, not `encodeURIComponent`. So, we should use `decodeURI` to decode it.
- We also wrap `Signup` component with `UnauthenticatedRoute` which is responsible for redirecting. So we should remove a redirecting logic in `Signup` to prevent conflicts.