### PR TITLE
Explanation of ReturnValues in the Update Note API

### DIFF
--- a/_chapters/add-an-update-note-api.md
+++ b/_chapters/add-an-update-note-api.md
@@ -36,6 +36,9 @@ export async function main(event, context) {
       ":attachment": data.attachment || null,
       ":content": data.content || null
     },
+    // 'ReturnValues' specifies if and how to return the item's attributes,
+    // where ALL_NEW returns all attributes of the item after the update; you
+    // can inspect 'result' below to see how it works with different settings
     ReturnValues: "ALL_NEW"
   };
 


### PR DESCRIPTION
Absent any discussion, like the context given in #26, the presence of ReturnValues and the never-used result assignment may look like an error.