### PR TITLE
Adding Rust to the list of runtimes

### DIFF
--- a/_chapters/what-is-aws-lambda.md
+++ b/_chapters/what-is-aws-lambda.md
@@ -20,6 +20,7 @@ Let's start by quickly looking at the technical specifications of AWS Lambda. La
 - .NET Core: 1.0.1 and 2.0
 - Go 1.x
 - Ruby 2.5
+- Rust
 
 Each function runs inside a container with a 64-bit Amazon Linux AMI. And the execution environment has:
 


### PR DESCRIPTION
AWS recently [announced](https://aws.amazon.com/blogs/opensource/rust-runtime-for-aws-lambda/) a runtime for the Rust programming language.