### PR TITLE
Updating the lambda specs

### DIFF
--- a/_chapters/what-is-aws-lambda.md
+++ b/_chapters/what-is-aws-lambda.md
@@ -23,9 +23,9 @@ Let's start by quickly looking at the technical specifications of AWS Lambda. La
 
 Each function runs inside a container with a 64-bit Amazon Linux AMI. And the execution environment has:
 
-- Memory: 128MB - 3008MB
+- Memory: 128MB - 3008MB, in 64 MB increments
 - Ephemeral disk space: 512MB
-- Max execution duration: 300 seconds
+- Max execution duration: 900 seconds
 - Compressed package size: 50MB
 - Uncompressed package size: 250MB
 


### PR DESCRIPTION
AWS recently increased the Lambda timeouts to 900 seconds. Also adding that memory limits are available in 64MB increments. Full lambda specs are [here](https://docs.aws.amazon.com/lambda/latest/dg/limits.html)