### PR TITLE
Update how-to-get-help Portuguese version

### DIFF
--- a/_chapters/pt/how-to-get-help.md
+++ b/_chapters/pt/how-to-get-help.md
@@ -7,7 +7,7 @@ date: 2016-12-23 00:00:00
 comments_id: how-to-get-help/95
 ---
 
-Caso você tenha algum problema em algum passo específico, nós queremos ter certeza de acompanhá-lo e ajudar-lo nas suas dúvidas e problemas. Aqui vai algumas dicas de como conseguir ajuda.
+Caso você tenha algum problema em algum passo específico, nós queremos ter certeza de acompanhá-lo e ajudá-lo nas suas dúvidas e problemas. Aqui vão algumas dicas de como conseguir ajuda.
 
 - Nós usamos um [fórum]({{ site.forum_url }}) como sessão de comentários e com isso já ajudamos várias pessoas a resolver seus problemas no passado. Então, tenha certeza que sua dúvida ainda não foi sanada antes de fazer um novo comentário.
 - Poste no fórum específico do capítulo que você está tendo problemas para mantermos a organização.


### PR DESCRIPTION
two minor verbal agreement/conjugation mistakes
- Instead of 'ajudar-lo', the correct is 'ajudá-lo'
- Instead of 'vai', 'vão', to agree with 'algumas'.