### PR TITLE
Removing extra characters from resource

### DIFF
--- a/_chapters/create-a-cognito-identity-pool.md
+++ b/_chapters/create-a-cognito-identity-pool.md
@@ -81,7 +81,7 @@ In our case `YOUR_S3_UPLOADS_BUCKET_NAME` is `notes-app-uploads`, `YOUR_API_GATE
         "execute-api:Invoke"
       ],
       "Resource": [
-        "arn:aws:execute-api:YOUR_API_GATEWAY_REGION:*:YOUR_API_GATEWAY_ID/*/*/*"
+        "arn:aws:execute-api:YOUR_API_GATEWAY_REGION:*:YOUR_API_GATEWAY_ID/*"
       ]
     }
   ]


### PR DESCRIPTION
Removing extra characteres from execute-api resource that can cause a 403 error (Forbidden) and make it difficult to find where the problem is.

I took some time until figure it out