### PR TITLE
Updated Lambda runtimes

### DIFF
--- a/_chapters/what-is-aws-lambda.md
+++ b/_chapters/what-is-aws-lambda.md
@@ -14,10 +14,10 @@ comments_id: what-is-aws-lambda/308
 
 Let's start by quickly looking at the technical specifications of AWS Lambda. Lambda supports the following runtimes.
 
-- Node.js: v10.15 and v8.10
-- Java 8
-- Python: 3.7, 3.6, and 2.7
-- .NET Core: 1.0.1 and 2.1
+- Node.js 12.13.0, 10.16.3 and 8.10
+- Java 11 and 8
+- Python 3.8, 3.7, 3.6 and 2.7
+- .NET Core 2.1
 - Go 1.x
 - Ruby 2.5
 - Rust

--- a/_chapters/what-is-aws-lambda.md
+++ b/_chapters/what-is-aws-lambda.md
@@ -14,9 +14,9 @@ comments_id: what-is-aws-lambda/308
 
 Let's start by quickly looking at the technical specifications of AWS Lambda. Lambda supports the following runtimes.
 
-- Node.js 12.13.0, 10.16.3 and 8.10
+- Node.js 12.13.0, 10.16.3, and 8.10
 - Java 11 and 8
-- Python 3.8, 3.7, 3.6 and 2.7
+- Python 3.8, 3.7, 3.6, and 2.7
 - .NET Core 2.1
 - Go 1.x
 - Ruby 2.5


### PR DESCRIPTION
Reviewed the available Lambda runtimes at https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html and found significant differences as of 2019-11-21. Documented those updates.
Made the punctuation for all languages consistent.
Note that Rust isn't an officially supported runtime, but leaving it in for now.