### PR TITLE
Update add-a-get-note-api.md

### DIFF
--- a/_chapters/add-a-get-note-api.md
+++ b/_chapters/add-a-get-note-api.md
@@ -87,7 +87,7 @@ To test our get note API we need to mock passing in the `noteId` parameter. We a
 }
 ```
 
-And we invoke our newly created function.
+And invoke our newly created function from the root directory of the project.
 
 ``` bash
 $ serverless invoke local --function get --path mocks/get-event.json


### PR DESCRIPTION
Prior to this we're operating in "mocks"  it should be specified to invoke from the root of the project directory. In the next chapter "add-a-list-all-the-notes-api" it is specified in this format.