### PR TITLE
fix(docs): :pencil2: stick to jest expect convention

### DIFF
--- a/_chapters/unit-tests-in-serverless.md
+++ b/_chapters/unit-tests-in-serverless.md
@@ -46,28 +46,28 @@ import { calculateCost } from "../libs/billing-lib";
 test("Lowest tier", () => {
   const storage = 10;
 
-  const cost = 4000;
-  const expectedCost = calculateCost(storage);
+  const actualCost = calculateCost(storage);
+  const expectedCost = 4000;
 
-  expect(cost).toEqual(expectedCost);
+  expect(actualCost).toBe(expectedCost);
 });
 
 test("Middle tier", () => {
   const storage = 100;
 
-  const cost = 20000;
-  const expectedCost = calculateCost(storage);
+  const actualCost = calculateCost(storage);
+  const expectedCost = 20000;
 
-  expect(cost).toEqual(expectedCost);
+  expect(actualCost).toBe(expectedCost);
 });
 
 test("Highest tier", () => {
   const storage = 101;
 
-  const cost = 10100;
-  const expectedCost = calculateCost(storage);
+  const actualCost = calculateCost(storage);
+  const expectedCost = 10100;
 
-  expect(cost).toEqual(expectedCost);
+  expect(actualCost).toBe(expectedCost);
 });
 ```
 


### PR DESCRIPTION
https://jestjs.io/docs/en/expect#tobevalue

> Use .toBe() to compare primitive values or to check referential identity of object instances.

`.toEqual()` is rather used to compare the content of an object.

actual and expected values were also the other way around; The reference value is supposed to used as a parameter of the `toBe` function rather than the `expect` function.