### PR TITLE
Fixed a few typos and a bug

### DIFF
--- a/_chapters/logic-errors-in-lambda-functions.md
+++ b/_chapters/logic-errors-in-lambda-functions.md
@@ -10,7 +10,7 @@ ref: logic-errors-in-lambda-functions
 
 Now that we've [setup error logging for our API]({% link _chapters/setup-error-logging-in-serverless.md %}), we are ready to go over the workflow for debugging the various types of errors we'll run into.
 
-First up, are errors that can happen in our Lambda function code. Now we all know that we almost never make mistakes in our code. However, it's still worth going over this very _"unlikely"_ scenario.
+First up, there are errors that can happen in our Lambda function code. Now we all know that we almost never make mistakes in our code. However, it's still worth going over this very _"unlikely"_ scenario.
 
 ### Create a New Branch
 

--- a/_chapters/logic-errors-in-lambda-functions.md
+++ b/_chapters/logic-errors-in-lambda-functions.md
@@ -44,7 +44,7 @@ export const main = handler(async (event, context) => {
     }
   };
 
-  const result = await dynamoD.get(params);
+  const result = await dynamoDb.get(params);
   if ( ! result.Item) {
     throw new Error("Item not found.");
   }

--- a/_chapters/setup-an-error-boundary-in-react.md
+++ b/_chapters/setup-an-error-boundary-in-react.md
@@ -142,7 +142,7 @@ While developing, React doesn't show your Error Boundary fallback UI by default.
 
 Since we are developing locally, we don't report this error to Sentry. But let's do a quick test to make sure it's hooked up properly.
 
-Replace the following from the top of `src/libs/error-lib.js`.
+Replace the following from the top of `src/libs/errorLib.js`.
 
 ``` javascript
 const isLocal = process.env.NODE_ENV === "development";

--- a/_chapters/setup-error-reporting-in-react.md
+++ b/_chapters/setup-error-reporting-in-react.md
@@ -50,7 +50,7 @@ $ npm install @sentry/browser --save
 
 We are going to be using Sentry across our app. So it makes sense to keep all the Sentry related code in one place.
 
-<img class="code-marker" src="/assets/s.png" />Add the following to the top of your `src/libs/error-lib.js`.
+<img class="code-marker" src="/assets/s.png" />Add the following to the top of your `src/libs/errorLib.js`.
 
 ``` javascript
 import * as Sentry from "@sentry/browser";


### PR DESCRIPTION
I added a missing word in a paragraph, corrected the name of a file to stay consistent with the previous sections of the guideline, and I fixed a typo in the class name which provoked a webpack compilation error during the deployment process (i.e., "error  'dynamoD' is not defined no-undef").

