### PR TITLE
refactor: Ensure to use `change` image tag instead hardcoded image

### DIFF
--- a/_chapters/add-a-billing-api.md
+++ b/_chapters/add-a-billing-api.md
@@ -12,13 +12,13 @@ Now let's get started with creating our billing API. It is going to take a Strip
 
 ### Add a Billing Lambda
 
-<img class="code-marker" src="/assets/s.png" />Start by installing the Stripe NPM package. Run the following in the root of our project.
+{%change%}Start by installing the Stripe NPM package. Run the following in the root of our project.
 
 ``` bash
 $ npm install --save stripe
 ```
 
-<img class="code-marker" src="/assets/s.png" />Create a new file called 'billing.js' with the following.
+{%change%}Create a new file called 'billing.js' with the following.
 
 ``` js
 import stripePackage from "stripe";

--- a/_plugins/change.rb
+++ b/_plugins/change.rb
@@ -1,0 +1,9 @@
+module Jekyll
+  class Change < Liquid::Tag
+    def render(context)
+      "<img class=\"code-marker\" src=\"/assets/s.png\" />"
+    end
+  end
+end
+
+Liquid::Template.register_tag('change', Jekyll::Change)


### PR DESCRIPTION
Hey there. While making edits some time ago I noticed that the `CHANGE` utility image is hardcoded. To improve the author experience, I refactored it to use Jekyl's plugin system.

To find and replace throughout all files in `_chapters` folder , you may want to run this command inside project dir:
```
find _chapters \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i '' 's/<img class="code-marker" src="\/assets\/s\.png" \/>/\{%change%\}/g'
```
I didn't include the changes made by this command to make the code review simpler. However, feel free to run it yourself.

Hope this would add some value to this awesome guide.