### PR TITLE
Use "中文" to indicate Chinese translation

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -5,5 +5,5 @@ es: Spanish
 de: German
 fr: Français
 id: Indonesian
-zh: Chinese
+zh: 中文
 


### PR DESCRIPTION
This is more user-friendly for Chinese readers. The same word `中文` is also used in Wikipedia to indicate Chinese translation.