### PR TITLE
Updating the .Net Core supported versions

### DIFF
--- a/_chapters/what-is-aws-lambda.md
+++ b/_chapters/what-is-aws-lambda.md
@@ -17,7 +17,7 @@ Let's start by quickly looking at the technical specifications of AWS Lambda. La
 - Node.js 12.13.0, 10.16.3, and 8.10
 - Java 11 and 8
 - Python 3.8, 3.7, 3.6, and 2.7
-- .NET Core 2.1
+- .NET Core 2.1, 2.2, 3.0 and 3.1
 - Go 1.x
 - Ruby 2.5
 - Rust

--- a/_chapters/what-is-aws-lambda.md
+++ b/_chapters/what-is-aws-lambda.md
@@ -17,7 +17,7 @@ Let's start by quickly looking at the technical specifications of AWS Lambda. La
 - Node.js 12.13.0, 10.16.3, and 8.10
 - Java 11 and 8
 - Python 3.8, 3.7, 3.6, and 2.7
-- .NET Core 2.1, 2.2, 3.0 and 3.1
+- .NET Core 2.1, 2.2, 3.0, and 3.1
 - Go 1.x
 - Ruby 2.5
 - Rust


### PR DESCRIPTION
Adding that .Net core 2.2, 3.0 and 3.1 are now supported by AWS serverless functions
* https://aws.amazon.com/blogs/developer/announcing-amazon-lambda-runtimesupport/
* https://aws.amazon.com/blogs/developer/net-core-3-0-on-lambda-with-aws-lambdas-custom-runtime/
* https://aws.amazon.com/blogs/compute/announcing-aws-lambda-supports-for-net-core-3-1/