### PR TITLE
provide instruction for enabling on-demand

### DIFF
--- a/_chapters/create-a-dynamodb-table.md
+++ b/_chapters/create-a-dynamodb-table.md
@@ -47,6 +47,8 @@ Scroll down further and select **On-demand** instead of **Provisioned**.
 
 [On-Demand Capacity](https://aws.amazon.com/dynamodb/pricing/on-demand/) is DynamoDB's pay per request mode. For workloads that are not predictable or if you are just starting out, this ends up being a lot cheaper than the [Provisioned Capacity](https://aws.amazon.com/dynamodb/pricing/provisioned/) mode.
 
+If the On-Demand Capacity option is missing and there is an info box containing the message "You do not have the required role to enable Auto Scaling by default", you can create the table and afterwards modify the setting from the "Capacity" tab of the table settings page. The role mentioned by the info box is automatically created by the table creation process.
+
 Finally, scroll down and hit **Create**.
 
 ![Create DynamoDB table screenshot](/assets/dynamodb/create-dynamodb-table.png)


### PR DESCRIPTION
first table creation screen in the console does not contain the on-demand capacity option until after the first table has been created and the auto scaling role has been created.