### PR TITLE
Fixing a typo in the add-a-get-note-api.md

### DIFF
--- a/_chapters/add-a-get-note-api.md
+++ b/_chapters/add-a-get-note-api.md
@@ -38,7 +38,7 @@ export const main = handler(async (event, context) => {
 });
 ```
 
-This follows exactly the same structure as our previous `create.js` function. The major difference here is that we are doing a `dynamoDb.get(params)` to get a note object given the `noteId` (still hardcoded) and `userId` that is passed in through the request.
+This follows exactly the same structure as our previous `create.js` function. The major difference here is that we are doing a `dynamoDb.get(params)` to get a note object given the `userId` (still hardcoded) and `noteId` that is passed in through the request.
 
 ### Configure the API Endpoint
 


### PR DESCRIPTION
Fixing a typo where it says that noteId is hardcoded and the userId is passed through the request.