### PR TITLE
bump the node runtime to node14.x

### DIFF
--- a/_chapters/setup-the-serverless-framework.md
+++ b/_chapters/setup-the-serverless-framework.md
@@ -83,7 +83,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   stage: prod
   region: us-east-1
 


### PR DESCRIPTION
either bump the doc to the newest runtime or put a link to the lambda runtimes (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) 