### PR TITLE
Fix ApiAuthorizationTypes in Auth0 example

### DIFF
--- a/_examples/how-to-add-jwt-authorization-with-auth0-to-a-serverless-api.md
+++ b/_examples/how-to-add-jwt-authorization-with-auth0-to-a-serverless-api.md
@@ -72,7 +72,7 @@ export default class MyStack extends sst.Stack {
         jwtAudience: ["UsGRQJJz5sDfPQDs6bhQ9Oc3hNISuVif"],
         jwtIssuer: "https://myorg.us.auth0.com/",
       }),
-      defaultAuthorizationType: "JWT",
+      defaultAuthorizationType: sst.ApiAuthorizationType.JWT,
       routes: {
         "GET /private": "src/private.main",
         "GET /public": {

--- a/_examples/how-to-add-jwt-authorization-with-auth0-to-a-serverless-api.md
+++ b/_examples/how-to-add-jwt-authorization-with-auth0-to-a-serverless-api.md
@@ -76,7 +76,7 @@ export default class MyStack extends sst.Stack {
       routes: {
         "GET /private": "src/private.main",
         "GET /public": {
-          authorizationType: "NONE",
+          authorizationType: sst.ApiAuthorizationType.NONE,
           function: "src/public.main",
         },
       },


### PR DESCRIPTION
Example uses a string of "JWT" and "NONE" but that doesn't work as typescript requires the type coming from ApiAuthorizationType as per [the SST docs](https://docs.serverless-stack.com/constructs/Api).