### PR TITLE
Add note about using only User Pools with API Gateway

### DIFF
--- a/_chapters/handling-auth-in-serverless-apis.md
+++ b/_chapters/handling-auth-in-serverless-apis.md
@@ -111,7 +111,7 @@ Our React client will be directly uploading files to our S3 bucket. Similar to o
 
 It's worth quickly mentioning that there are other ways to secure your APIs. We mentioned above that an Identity Pool can use Facebook or Google as an authentication provider. So instead of using a User Pool, you can use Facebook or Google. We have an Extra Credits chapter on Facebook specifically — [Facebook Login with Cognito using AWS Amplify]({% link _chapters/facebook-login-with-cognito-using-aws-amplify.md %})
 
-You can also directly connect the User Pool to API Gateway. The downside with that is that you might not be able to manage access control centrally to the S3 bucket (or any other AWS resources in the future).
+You can also directly connect the User Pool to API Gateway. The downside with that is that you might not be able to manage access control centrally to the S3 bucket (or any other AWS resources in the future). Also, if you want to allow any kind of unauthenticated access to your service in the future, you won't be able to do this if you only use a User Pool with API Gateway. Only Identity Pools allow for unauthenticated access.
 
 Finally, you can manage your users and authentication yourself. This is a little bit more complicated and we are not covering it in this guide. Though we might expand on it later.
 


### PR DESCRIPTION
I tripped up when using only User Pools as API Gateway authentication.