### PR TITLE
Shared Config with common YML almost deprecated

### DIFF
--- a/_chapters/share-code-between-services.md
+++ b/_chapters/share-code-between-services.md
@@ -2,7 +2,7 @@
 layout: post
 title: Share Code Between Services
 description: In this chapter we look at how to share common code and config between services in your Serverless app. We'll look at how to structure the package.json and share config between multiple serverless.yml files.
-date: 2019-09-29 00:00:00
+date: 2021-06-05 00:00:00
 comments_id: share-code-between-services/1333
 ---
 


### PR DESCRIPTION
Per [this discussion](https://github.com/serverless/serverless/issues/9095) in the Serverless repo, soon the ability to access a shared configuration outside the individual services' directory will no longer be possible without experiencing thrown errors.