### PR TITLE
clarify how deployed Stack name is created / controlled

### DIFF
--- a/_chapters/create-a-dynamodb-table-in-sst.md
+++ b/_chapters/create-a-dynamodb-table-in-sst.md
@@ -92,6 +92,8 @@ Stack dev-notes-storage
   Status: deployed
 ```
 
+The `Stack` name above of `dev-notes-storage` is a string derived from your environment-appName-stackName. Your appName is defined in the 'name' field of your `package.json` file and your stackName is the label you choose for your stack in `lib/index.js'.
+
 ### Remove Template Files
 
 There are a couple of files that came with our starter template, that we can now remove.

--- a/_chapters/create-a-dynamodb-table-in-sst.md
+++ b/_chapters/create-a-dynamodb-table-in-sst.md
@@ -92,7 +92,7 @@ Stack dev-notes-storage
   Status: deployed
 ```
 
-The `Stack` name above of `dev-notes-storage` is a string derived from your environment-appName-stackName. Your appName is defined in the 'name' field of your `package.json` file and your stackName is the label you choose for your stack in `lib/index.js'.
+The `Stack` name above of `dev-notes-storage` is a string derived from your `${stageName}-${appName}-${stackName}`. Your `appName` is defined in the `name` field of your `sst.json` file and your `stackName` is the label you choose for your stack in `lib/index.js'.
 
 ### Remove Template Files
 


### PR DESCRIPTION
perhaps this is overkill, but as a new SST user, I found myself unclear on this at first until I found the name created by the boilerplate in package.json