### PR TITLE
update content to match earlier infrastructure

### DIFF
--- a/_chapters/review-our-app-architecture.md
+++ b/_chapters/review-our-app-architecture.md
@@ -12,11 +12,11 @@ So far we've [deployed our simple Hello World API]({% link _chapters/deploy-your
 
 ### Hello World API Architecture
 
-Here's what we've built so far in our Hello World API.
+Here's what was built initially when we created the SST boilerplate application with its Hello World API.
 
 ![Serverless Hello World API architecture](/assets/diagrams/serverless-hello-world-api-architecture.png)
 
-API Gateway handles the `https://0f7jby961h.execute-api.us-east-1.amazonaws.com/prod` endpoint for us. And any GET requests made to `/hello`, are sent to our `hello.js` Lambda function.
+API Gateway handles our main `/` endpoint, sending GET requests made to this to our default `src/lambda.js` Lambda function.
 
 ### Notes App API Architecture
 


### PR DESCRIPTION
update content to match 'hello world' infrastructure created by current boilerplate project and referenced in earlier steps of SST guide

note - screenshot should also be updated to update endpoint and lamba labels