### PR TITLE
Add region into resource for events portion

### DIFF
--- a/_chapters/customize-the-serverless-iam-policy.md
+++ b/_chapters/customize-the-serverless-iam-policy.md
@@ -227,7 +227,7 @@ Below is a more nuanced policy template that restricts access to the serverless 
         "events:Delete*",
         "events:Describe*"
       ],
-      "Resource": "arn:aws:events::<account_no>:rule/<service_name>*"
+      "Resource": "arn:aws:events:<region>:<account_no>:rule/<service_name>*"
     }
   ]
 }


### PR DESCRIPTION
Add's the `<region>` which is missing in `"Resource": "arn:aws:events::<account_no>:rule/<service_name>*"` for the events example.