### PR TITLE
Pin a specific version of react-router-bootstrap

### DIFF
--- a/_chapters/adding-links-in-the-navbar.md
+++ b/_chapters/adding-links-in-the-navbar.md
@@ -57,7 +57,7 @@ To fix this we need a component that works with React Router and React Bootstrap
 {%change%} Run the following command in the `frontend/` directory and **not** in your project root.
 
 ``` bash
-$ npm install react-router-bootstrap
+$ npm install react-router-bootstrap@0.25.0
 ```
 
 Let's also import it.


### PR DESCRIPTION
While working through the guide a reader ran into the following error after installing `react-router-bootstrap`

```
react-router-dom usenavigate is not a function
```
Because `useNavigate` is new, I figured that it was that. Seemed to work for that reader. 


https://serverless-stack.slack.com/archives/C01JVDJQU2C/p1640895637087800