### PR TITLE
Update how-to-create-a-websocket-api-with-serverless.md

### DIFF
--- a/_examples/how-to-create-a-websocket-api-with-serverless.md
+++ b/_examples/how-to-create-a-websocket-api-with-serverless.md
@@ -99,8 +99,8 @@ const api = new sst.WebSocketApi(this, "Api", {
     },
   },
   routes: {
-    $connect: "src/connect.main",
-    $disconnect: "src/disconnect.main",
+    connect: "src/connect.main",
+    disconnect: "src/disconnect.main",
     sendmessage: "src/sendMessage.main",
   },
 });


### PR DESCRIPTION
two routes in MyStack begin with a '$' by mistake. These result in timed-out websocket connections responses with 502 bad gateway responses.