### PR TITLE
Updating the mailto links on the careers page

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -20,21 +20,21 @@ description: We want to build the future of serverless. If you are passionate ab
         <h3>Software Engineering</h3>
         <p>We are looking for software engineers to help build out our open source framework, SST. SST is primarily written in TypeScript and Node.js. Knowledge of other languages is a bonus. It'll also be helpful if you have a general understanding of some AWS services. Please share some of your open source contributions with us and links to projects that you've worked on. If you care about building better developer tools, we'd love to meet you.</p>
       </div>
-      <a href="mailto: {{ site.jobs_email }}">Contact us</a>
+      <a href="mailto:{{ site.jobs_email }}">Contact us</a>
     </li>
     <li>
       <div>
         <h3>Technical Writing</h3>
         <p>We need technical writers to help grow our guide. If you like taking complicated concepts and finding ways to convey them in as simple of a way as as possible, we'd love to talk to you. It's a big bonus if you like teaching or have created educational content in the past. Please share articles, guides, tutorials, or docs that you've written.</p>
       </div>
-      <a href="mailto: {{ site.jobs_email }}">Contact us</a>
+      <a href="mailto:{{ site.jobs_email }}">Contact us</a>
     </li>
     <li>
       <div>
         <h3>Visual Design</h3>
         <p>We could use some visual design help to create the graphical elements that we use across our entire portfolio. This includes things like icons, logos, posters, inforgraphics, UI design elements, and much more. If you like using design to make the complex more accessible, please send us your portfolio. We'd love to get in touch!</p>
       </div>
-      <a href="mailto: {{ site.jobs_email }}">Contact us</a>
+      <a href="mailto:{{ site.jobs_email }}">Contact us</a>
     </li>
   </ul>
 


### PR DESCRIPTION
I was applying for a job and the spaces in the mailto were adding %20 into the email address when copy/pasting from the link.