### PR TITLE
Update adding-auth-to-our-serverless-app.md

### DIFF
--- a/_chapters/adding-auth-to-our-serverless-app.md
+++ b/_chapters/adding-auth-to-our-serverless-app.md
@@ -30,7 +30,7 @@ export function AuthStack({ stack, app }) {
   const { api } = use(ApiStack);
 
   // Create a Cognito User Pool and Identity Pool
-  const auth = new Auth(stack, "Auth", {
+  const auth = new Cognito(stack, "Auth", {
     login: ["email"],
   });
 


### PR DESCRIPTION
Was throwing error: `Error: It looks like you may be passing in Cognito props to the Auth construct. The Auth construct was renamed to Cognito in version 1.10.0`. Updating code example to align with new version.