### PR TITLE
Correct import statement in AuthStack.js

### DIFF
--- a/_chapters/adding-auth-to-our-serverless-app.md
+++ b/_chapters/adding-auth-to-our-serverless-app.md
@@ -21,7 +21,7 @@ Setting this all up can be pretty complicated in CDK. SST has a simple [`Auth`](
 
 ```js
 import * as iam from "aws-cdk-lib/aws-iam";
-import { Auth, use } from "@serverless-stack/resources";
+import { Cognito, use } from "@serverless-stack/resources";
 import { StorageStack } from "./StorageStack";
 import { ApiStack } from "./ApiStack";
 


### PR DESCRIPTION
When re-deploying the stack a warning was shown, indicating `Cognito` was not imported. Since `Auth` was, but not used (possibly from a previous example?), I replaced this with `Cognito`. Deployment worked as expected after this change.