### PR TITLE
(docs) Update 'How to use Lambda Layers' example with

### DIFF
--- a/_examples/how-to-use-lambda-layers-in-your-serverless-app.md
+++ b/_examples/how-to-use-lambda-layers-in-your-serverless-app.md
@@ -90,7 +90,7 @@ export function ExampleStack({ stack }: StackContext) {
           // Load Chrome in a Layer
           layers: [layer],
           // Exclude bundling it in the Lambda function
-          bundle: { externalModules: ["chrome-aws-lambda"] },
+          nodejs: { install: ["chrome-aws-lambda"] },
         },
       },
     },


### PR DESCRIPTION
While I still [struggling to run ](https://discord.com/channels/983865673656705025/1085095799416967259)this example, I still think the proposed change should be implemented. Otherwise TS compiler complains with this:
```
Type '{ externalModules: string[]; }' is not assignable to type 'NodeJSProps'
```