### PR TITLE
docs: update from clear to remove

### DIFF
--- a/_examples/how-to-add-facebook-login-to-your-sst-apps.md
+++ b/_examples/how-to-add-facebook-login-to-your-sst-apps.md
@@ -500,7 +500,7 @@ And finally, when the user clicks on `Sign out`, we need to clear the session to
 
 ```ts
 const signOut = async () => {
-  localStorage.clear("session");
+  localStorage.removeItem("session");
   setSession(null);
 };
 ```

--- a/_examples/how-to-add-google-login-to-your-sst-apps.md
+++ b/_examples/how-to-add-google-login-to-your-sst-apps.md
@@ -503,7 +503,7 @@ And finally, when the user clicks on `Sign out`, we need to clear the session to
 
 ```ts
 const signOut = async () => {
-  localStorage.clear("session");
+  localStorage.removeItem("session");
   setSession(null);
 };
 ```


### PR DESCRIPTION
While working through auth I noticed that this was clearing with an argument. What it should actually do is remove the item that's set previously. 

You can see the docs here:
https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#examples

There's [another PR here](https://github.com/serverless-stack/sst/pull/2679) for `sst`