### PR TITLE
Update mapping-cognito-identity-id-and-user-pool-id.md

### DIFF
--- a/_chapters/mapping-cognito-identity-id-and-user-pool-id.md
+++ b/_chapters/mapping-cognito-identity-id-and-user-pool-id.md
@@ -24,8 +24,8 @@ However, you might find yourself looking for a user's User Pool user id in your 
 Below is a sample Lambda function where we find the user's User Pool user id.
 
 ``` js
-export async function main(event, context, callback) {
-  const authProvider = event.requestContext.identity.cognitoAuthenticationProvider;
+export async function main(event, context) {
+  const authProvider = event.requestContext.authorizer.iam.cognitoIdentity.amr.findLast(ref => ref.includes(':'))
   // Cognito authentication provider looks like:
   // cognito-idp.us-east-1.amazonaws.com/us-east-1_xxxxxxxxx,cognito-idp.us-east-1.amazonaws.com/us-east-1_aaaaaaaaa:CognitoSignIn:qqqqqqqq-1111-2222-3333-rrrrrrrrrrrr
   // Where us-east-1_aaaaaaaaa is the User Pool id


### PR DESCRIPTION
Full disclosure, I gotta run to work in a few minutes and don't have time to check this out in-depth, but:

I couldn't find any documentation on AWS's end about this, it just seems that `event.requestContext.identity` is always undefined when using `iam` as an authorizer. My guess is that they switched to `event.requestContext.authorizer.iam` at some point. 

There's probably a better way of doing this, but here's my solution this morning: `const authProvider = event.requestContext.authorizer.iam.cognitoIdentity.amr.findLast(ref => ref.includes(':'))`


For reference here's my output of `event.requestContext.authorizer.iam`

```
event.requestContext.authorizer.iam {
  accessKey: 'accessKey',
  accountId: 'accountId',
  callerId: 'callerId:CognitoIdentityCredentials',
  cognitoIdentity: {
    amr: [
      'authenticated',
      'cognito-idp.us-west-2.amazonaws.com/us-west-2_abcdef',
      'cognito-idp.us-west-2.amazonaws.com/us-west-2_abcdef:CognitoSignIn:user_pool_user_id'
    ],
    identityId: 'us-west-2:identityId',
    identityPoolId: 'us-west-2:identityPoolId'
  },
  principalOrgId: null,
  userArn: 'arn:aws:sts::me:assumed-role/sam-cognito-test-API-AuthIdentityPoolAuthRole_role/CognitoIdentityCredentials',
  userId: 'userId:CognitoIdentityCredentials'
}
```