### PR TITLE
Update how-to-create-a-nextjs-app-with-serverless.md

### DIFF
--- a/_examples/how-to-create-a-nextjs-app-with-serverless.md
+++ b/_examples/how-to-create-a-nextjs-app-with-serverless.md
@@ -42,6 +42,7 @@ This will detect that you are trying to configure a Next.js app. It'll add a `ss
 
 ```js
 import { SSTConfig } from "sst";
+import { NextjsSite } from "sst/constructs";
 
 export default {
   config(_input) {


### PR DESCRIPTION
Going through the example docs, the first code block is missing one import statement.

`import {NextjsSite} from 'sst/constructs';`

Have added it in following the format.