### PR TITLE
[docs] Update jwt-with-auth0

### DIFF
--- a/_examples/how-to-add-jwt-authorization-with-auth0-to-a-serverless-api.md
+++ b/_examples/how-to-add-jwt-authorization-with-auth0-to-a-serverless-api.md
@@ -84,6 +84,15 @@ Note, after deployment you need to replace these values with the deployed URL.
 
 ![Auth0 URLs setup](/assets/examples/api-auth-jwt-auth0/auth0-urls-setup.png)
 
+## Setting the Environment Variables
+
+Edit (or create) a file at the root of your project named `.env` and add the following to it:
+
+```
+AUTH0_DOMAIN=<YOUR_AUTH0_DOMAIN>
+AUTH0_CLIENT_ID=<YOUR_AUTH0_CLIENT_ID>
+```
+
 ## Setting up the API
 
 Let's start by setting up an API.
@@ -102,8 +111,8 @@ export function ExampleStack({ stack, app }: StackContext) {
       auth0: {
         type: "jwt",
         jwt: {
-          issuer: process.env.AUTH0_DOMAIN + "/",
-          audience: [process.env.AUTH0_DOMAIN + "/api/v2/"],
+          issuer: `https://${process.env.AUTH0_DOMAIN}/`,
+          audience: [`https://${process.env.AUTH0_DOMAIN}/api/v2/`],
         },
       },
     },

--- a/_examples/how-to-add-jwt-authorization-with-auth0-to-a-serverless-api.md
+++ b/_examples/how-to-add-jwt-authorization-with-auth0-to-a-serverless-api.md
@@ -112,7 +112,10 @@ export function ExampleStack({ stack, app }: StackContext) {
         type: "jwt",
         jwt: {
           issuer: `https://${process.env.AUTH0_DOMAIN}/`,
-          audience: [`https://${process.env.AUTH0_DOMAIN}/api/v2/`],
+          audience: [
+            `${process.env.AUTH0_CLIENT_ID}`,
+            `https://${process.env.AUTH0_DOMAIN}/api/v2/`,
+          ],
         },
       },
     },


### PR DESCRIPTION
- add step to create/update the .env file with AUTH0 values
- modified the `authorizers.auth0.jwt.issuer` value to be a full URL
  - without the https:// the value led to the error:
```
Resource handler returned message: "Invalid issuer: Issuer is not a valid URL for JWT Authorizer (Service: AmazonApiGatewayV2; Status Code: 400; Error Code: BadRequestException; ....
```