### PR TITLE
fix: use correct curl command for creating notes

### DIFF
--- a/_chapters/secure-our-serverless-apis.md
+++ b/_chapters/secure-our-serverless-apis.md
@@ -132,7 +132,7 @@ While this might look intimidating, just keep in mind that behind the scenes all
 If you are on Windows, use the command below. The space between each option is very important.
 
 ```bash
-$ npx aws-api-gateway-cli-test --username admin@example.com --password Passw0rd! --user-pool-id USER_POOL_ID --app-client-id USER_POOL_CLIENT_ID --cognito-region COGNITO_REGION --identity-pool-id IDENTITY_POOL_ID --invoke-url API_ENDPOINT --api-gateway-region API_REGION --path-template /notes --method POST --body "{\"content\":\"hello world\",\"attachment\":\"hello.jpg\"}"
+$ npx aws-api-gateway-cli-test --username admin@example.com --password Passw0rd! --user-pool-id USER_POOL_ID --app-client-id USER_POOL_CLIENT_ID --cognito-region COGNITO_REGION --identity-pool-id IDENTITY_POOL_ID --invoke-url API_ENDPOINT --api-gateway-region API_REGION --path-template /notes --method POST --body '{""content\":\"hello world\",\"attachment\":\"hello.jpg\"}'
 ```
 
 If the command is successful, the response will look similar to this.


### PR DESCRIPTION
# Issue
The original request body of the example has parsing issues once executed, I've updated it with the payload that worked for me.

## Details
❌ Console outputs when using `--body "{\"content\":\"hello world\",\"attachment\":\"hello.jpg\"}"`
```
Getting temporary credentials
Making API request
undefined:1
{\
 ^

    at JSON.parse (<anonymous>)
    at makeRequest (C:\Users\admin\AppData\Local\npm-cache\_npx\ea84c6478cf14779\node_modules\aws-api-gateway-cli-test\index.js:179:17)

etc etc
```

✅ Console outputs when using `--body '{""content\":\"hello world\",\"attachment\":\"hello.jpg\"}'
`
```
Authenticating with User Pool
Getting temporary credentials
Making API request
{
  status: 200,
  statusText: 'OK',
  data: {
    userId: 'PLACEHOLDER',
    noteId: 'PLACEHOLDER',
    content: 'hello world',
    attachment: 'hello.jpg',
    createdAt: PLACEHOLDER
  }
}
```